### PR TITLE
Feature: Booth notes

### DIFF
--- a/src/routes/events/$eventId/booths/$boothId/index.tsx
+++ b/src/routes/events/$eventId/booths/$boothId/index.tsx
@@ -3,7 +3,7 @@ import { useEventData } from '@/contexts/EventDataContext';
 import { Event } from '@/types/Event';
 import { Booth } from '@/types/Booth';
 import { S3DataClient } from '@/utils/S3DataClient';
-import { Stack, Group, getGradient, Box, Image, Text, Title, useMantineTheme, getThemeColor, Button, ButtonGroup, Pill, Badge, rem, Grid } from '@mantine/core'
+import { Stack, Group, getGradient, Box, Image, Text, Title, useMantineTheme, getThemeColor, Button, ButtonGroup, Pill, Badge, rem, Grid, Textarea } from '@mantine/core'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useEffect, useMemo, useState } from 'react';
 import { MdCheckCircle, MdInfo, MdNote, MdNotes, MdOutlineRadioButtonChecked, MdTag } from 'react-icons/md';
@@ -28,7 +28,8 @@ function RouteComponent() {
     const { 
         isFavouriteBooth, addFavouriteBooth, removeFavouriteBooth,
         isBookmarkedBooth, addBookmarkedBooth, removeBookmarkedBooth,
-        isPlannedBooth, setPlannedBooth, removePlannedBooth
+        isPlannedBooth, setPlannedBooth, removePlannedBooth,
+        setBoothNote, getBoothNote, removeBoothNote,
      } = useEventUserDataStore(eventId);
 
     const [event, setEvent] = useState<Event|undefined>();
@@ -462,6 +463,18 @@ function RouteComponent() {
                                     </Button>
                                 )}
                             </ButtonGroup>
+                            <Textarea 
+                                w={"100%"}
+                                placeholder="Write your notes here..."
+                                autosize
+                                minRows={4}
+                                maxRows={4}
+                                maxLength={500}
+                                value={getBoothNote(booth.id) || ""}
+                                onChange={(e) => {
+                                    setBoothNote(booth.id, e.currentTarget.value);
+                                }}
+                            />
                         </Stack>
                     </Stack>
                 </Grid.Col>

--- a/src/stores/EventUserDataStore/index.ts
+++ b/src/stores/EventUserDataStore/index.ts
@@ -22,6 +22,10 @@ type EventUserDataStore = {
     isPlannedBooth: (boothId: number) => PlannedBoothStage;
     setPlannedBooth: (boothId: number, stage: PlannedBoothStage) => void;
     removePlannedBooth: (boothId: number) => void;
+    boothNotes: { [boothId: number]: string };
+    setBoothNote: (boothId: number, note: string) => void;
+    getBoothNote: (boothId: number) => string | undefined;
+    removeBoothNote: (boothId: number) => void;
     lastUpdated: Date | null;
 }
 
@@ -92,6 +96,22 @@ function _useEventUserDataStore(eventId: string) {
                     state.lastUpdated = new Date();
                 });
             },
+            boothNotes: {},
+            setBoothNote: (boothId: number, note: string) => {
+                set((state) => {
+                    state.boothNotes[boothId] = note;
+                    state.lastUpdated = new Date();
+                });
+            },
+            getBoothNote: (boothId: number) => {
+                return get().boothNotes[boothId];
+            },
+            removeBoothNote: (boothId: number) => {
+                set((state) => {
+                    delete state.boothNotes[boothId];
+                    state.lastUpdated = new Date();
+                });
+            },
             lastUpdated: null as Date | null,
         })),
         {
@@ -101,6 +121,7 @@ function _useEventUserDataStore(eventId: string) {
                 favouriteBooths: state.favouriteBooths,
                 bookmarkedBooths: state.bookmarkedBooths,
                 plannedBooths: state.plannedBooths,
+                boothNotes: state.boothNotes,
                 lastUpdated: state.lastUpdated,
             }),
             storage: createJSONStorage(() => localStorage),


### PR DESCRIPTION
Task: Add a text area for user to write their own notes for a booth

Details:
- Notes are stored in LocalStorage just like other favourite/bookmark flags
- Max characters: 500 (Not setting a limit may overwhelm the limit of LocalStorage)
- When there are more than 4 lines, scroll in text area enabled

UI Preview:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/525a8dee-5c44-4a1e-89da-71984b51e3b5" />
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/83182fb9-583a-4c24-9f90-5bb622ebdb64" />
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/5481ec46-07ed-4606-81ba-85636181aa7f" />
